### PR TITLE
test: remove e2e tests from gh action

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -98,9 +98,6 @@ jobs:
       - name: Run unit and integration tests
         run: npm run test:ci
         
-      - name: Run e2e tests
-        run: npm run e2e:ci
-        
       - name: Upload test coverage
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Entfernt e2e tests aus der GH-Action. Dies verursacht zurzeit zu viele Probleme und behindert das Vorankommen in der Entwicklung.